### PR TITLE
Remove Module.php's requirement for php short tags

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace SpeckInstall;
 


### PR DESCRIPTION
I spent embarrassingly too long hunting down this problem.
Short tags are not PSR-0 compliant.
